### PR TITLE
Adding botkube chart with existing secret

### DIFF
--- a/charts/botkube/.helmignore
+++ b/charts/botkube/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/botkube/Chart.yaml
+++ b/charts/botkube/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+name: botkube
+home: https://www.botkube.io
+version: v0.12.0
+appVersion: v0.12.0
+icon: https://www.botkube.io/images/botkube.ico
+description: Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster,
+ debug deployments and run specific checks on resources in the cluster.
+sources:
+  - https://github.com/infracloudio/botkube
+keywords:
+  - botkube
+  - kubernetes
+  - kubernetes-monitoring
+  - kubernetes-controller
+  - kubernetes-bot
+  - chatops
+  - bot
+  - botops
+maintainers:
+  - name: PrasadG193
+    email: prasad.ghangal@gmail.com
+  - name: ssudake21
+    email: sanket@infracloud.io

--- a/charts/botkube/Chart.yaml
+++ b/charts/botkube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: botkube
 home: https://www.botkube.io
-version: v0.12.0
+version: v0.12.1
 appVersion: v0.12.0
 icon: https://www.botkube.io/images/botkube.ico
 description: Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster,

--- a/charts/botkube/Chart.yaml
+++ b/charts/botkube/Chart.yaml
@@ -18,7 +18,5 @@ keywords:
   - bot
   - botops
 maintainers:
-  - name: PrasadG193
-    email: prasad.ghangal@gmail.com
-  - name: ssudake21
-    email: sanket@infracloud.io
+  - name: ebrianne
+    email: eldwan35@gmail.com

--- a/charts/botkube/README.md
+++ b/charts/botkube/README.md
@@ -1,0 +1,109 @@
+# BotKube
+
+![Version: v0.11.0](https://img.shields.io/badge/Version-v0.11.0-informational?style=flat-square) ![AppVersion: v0.11.0](https://img.shields.io/badge/AppVersion-v0.11.0-informational?style=flat-square)
+
+Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster, debug deployments and run specific checks on resources in the cluster.
+
+**Homepage:** <https://www.botkube.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| PrasadG193 | prasad.ghangal@gmail.com |  |
+| ssudake21 | sanket@infracloud.io |  |
+
+## Source Code
+
+* <https://github.com/infracloudio/botkube>
+
+### Now Supports AWS IRSA on EKS
+
+AWS has introduced IAM Role for Service Accounts in order to provide fine grained access. This is useful if you are looking to run BotKube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+
+Annotate the BotKube Service Account as shown in the example below and add the necessary Trust Relationship to the corresponding BotKube role to get this working
+
+```
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: "<role_arn_to_assume>"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| communications.elasticsearch.awsSigning.awsRegion | string | `"us-east-1"` |  |
+| communications.elasticsearch.awsSigning.enabled | bool | `false` |  |
+| communications.elasticsearch.awsSigning.roleArn | string | `""` |  |
+| communications.elasticsearch.enabled | bool | `false` |  |
+| communications.elasticsearch.index.name | string | `"botkube"` |  |
+| communications.elasticsearch.index.replicas | int | `0` |  |
+| communications.elasticsearch.index.shards | int | `1` |  |
+| communications.elasticsearch.index.type | string | `"botkube-event"` |  |
+| communications.elasticsearch.password | string | `"ELASTICSEARCH_PASSWORD"` |  |
+| communications.elasticsearch.server | string | `"ELASTICSEARCH_ADDRESS"` |  |
+| communications.elasticsearch.username | string | `"ELASTICSEARCH_USERNAME"` |  |
+| communications.mattermost.channel | string | `"MATTERMOST_CHANNEL"` |  |
+| communications.mattermost.enabled | bool | `false` |  |
+| communications.mattermost.notiftype | string | `"short"` |  |
+| communications.mattermost.team | string | `"MATTERMOST_TEAM"` |  |
+| communications.mattermost.token | string | `"MATTERMOST_TOKEN"` |  |
+| communications.mattermost.url | string | `"MATTERMOST_SERVER_URL"` |  |
+| communications.slack.channel | string | `"SLACK_CHANNEL"` |  |
+| communications.slack.enabled | bool | `false` |  |
+| communications.slack.notiftype | string | `"short"` |  |
+| communications.slack.token | string | `"SLACK_API_TOKEN"` |  |
+| communications.teams.appID | string | `"APPLICATION_ID"` |  |
+| communications.teams.appPassword | string | `"APPLICATION_PASSWORD"` |  |
+| communications.teams.enabled | bool | `false` |  |
+| communications.teams.notiftype | string | `"short"` |  |
+| communications.teams.port | int | `3978` |  |
+| communications.webhook.enabled | bool | `false` |  |
+| communications.webhook.url | string | `"WEBHOOK_URL"` |  |
+| config.recommendations | bool | `true` |  |
+| config.resources | list | [] | |
+| config.settings.clustername | string | `"not-configured"` |  |
+| config.settings.configwatcher | bool | `true` |  |
+| config.settings.kubectl.commands.resources | list | [] |  |
+| config.settings.kubectl.commands.verbs | list | [] |  |
+| config.settings.kubectl.defaultNamespace | string | `"default"` |  |
+| config.settings.kubectl.enabled | bool | `false` |  |
+| config.settings.kubectl.restrictAccess | bool | `false` |  |
+| config.settings.upgradeNotifier | bool | `true` |  |
+| config.ssl.enabled | bool | `false` |  |
+| extraAnnotations | object | `{}` |  |
+| extraEnv | string | `nil` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"infracloudio/botkube"` |  |
+| image.tag | string | `"latest"` |  |
+| ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
+| ingress.create | bool | `false` |  |
+| ingress.host | string | `"HOST"` |  |
+| ingress.tls.enabled | bool | `false` |  |
+| ingress.tls.secretName | string | `""` |  |
+| ingress.urlPath | string | `"/"` |  |
+| logLevel | string | `"info"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podSecurityPolicy.enabled | bool | `false` |  |
+| priorityClassName | string | `""` |  |
+| rbac.create | bool | `true` |  |
+| rbac.rules | list | [] |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext.runAsGroup | int | `101` |  |
+| securityContext.runAsUser | int | `101` |  |
+| service.name | string | `"metrics"` |  |
+| service.port | int | `2112` |  |
+| service.targetPort | int | `2112` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.interval | string | `"10s"` |  |
+| serviceMonitor.labels | object | `{}` |  |
+| serviceMonitor.path | string | `"/metrics"` |  |
+| serviceMonitor.port | string | `"metrics"` |  |
+| tolerations | list | `[]` |  |

--- a/charts/botkube/templates/_helpers.tpl
+++ b/charts/botkube/templates/_helpers.tpl
@@ -42,6 +42,6 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{- define "botkube.secretName" -}}
-{{- default ( {{ include "botkube.fullname" }}-communication-secret .) (.Values.communication.existingSecretName) -}}
+{{- define "botkube.CommunicationsSecretName" -}}
+{{- default (include "botkube.fullname" .) (.Values.communications.existingSecretName) "-communication-secret" -}}
 {{- end -}}

--- a/charts/botkube/templates/_helpers.tpl
+++ b/charts/botkube/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "botkube.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "botkube.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "botkube.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "botkube.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ include "botkube.fullname" . }}-sa
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "botkube.secretName" -}}
+{{- default ( {{ include "botkube.fullname" }}-communication-secret .) (.Values.communication.existingSecretName) -}}
+{{- end -}}

--- a/charts/botkube/templates/clusterrole.yaml
+++ b/charts/botkube/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "botkube.fullname" . }}-clusterrole
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+{{- with .Values.rbac.rules }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["botkube-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+{{ end }}
+{{ end }}

--- a/charts/botkube/templates/clusterrolebinding.yaml
+++ b/charts/botkube/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "botkube.fullname" . }}-clusterrolebinding
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "botkube.fullname" . }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ include "botkube.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/botkube/templates/communicationsecret.yaml
+++ b/charts/botkube/templates/communicationsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "botkube.fullname" . }}-communication-secret
+  name: {{ include "botkube.CommunicationsSecretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "botkube.name" . }}
     helm.sh/chart: {{ include "botkube.chart" . }}

--- a/charts/botkube/templates/communicationsecret.yaml
+++ b/charts/botkube/templates/communicationsecret.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.communications.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "botkube.fullname" . }}-communication-secret
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+stringData:
+  comm_config.yaml: |
+    # Communication settings
+    communications:
+      {{- with .Values.communications }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/botkube/templates/configmap.yaml
+++ b/charts/botkube/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "botkube.fullname" . }}-configmap
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  resource_config.yaml: |
+  {{- with .Values.config }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+

--- a/charts/botkube/templates/deployment.yaml
+++ b/charts/botkube/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - configMap:
                 name: {{ include "botkube.fullname" . }}-configmap
             - secret:
-                name: {{ include "botkube.secretName" . }}
+                name: {{ include "botkube.CommunicationsSecretName" . }}
       {{- if .Values.config.ssl.enabled }} 
         - name: certs
           secret:

--- a/charts/botkube/templates/deployment.yaml
+++ b/charts/botkube/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "botkube.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: controller
+    app: botkube
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      component: controller
+      app: botkube
+  template:
+    metadata:
+      labels:
+        component: controller
+        app: botkube
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.extraAnnotations }}
+{{ toYaml .Values.extraAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      serviceAccountName: {{ include "botkube.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: "/config"
+          {{- if .Values.config.ssl.enabled }}
+            - name: certs
+              mountPath: "/etc/ssl/certs"
+          {{ end }}
+          env:
+            - name: CONFIG_PATH
+              value: "/config/"
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
+            - name: BOTKUBE_VERSION
+              value: {{ .Chart.Version }}
+            - name: METRICS_PORT
+              value: {{ .Values.service.targetPort | quote }}
+        {{- if .Values.extraEnv }}
+          {{- range $name, $value := .Values.extraEnv }}
+            - name: {{ $name }}
+              value: {{ quote $value }}
+          {{- end }}
+        {{- end }}
+          {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
+      volumes:
+        - name: config-volume
+          projected:
+            sources:
+            - configMap:
+                name: {{ include "botkube.fullname" . }}-configmap
+            - secret:
+                name: {{ include "botkube.secretName" . }}
+      {{- if .Values.config.ssl.enabled }} 
+        - name: certs
+          secret:
+            secretName: {{ include "botkube.fullname" . }}-certificate-secret
+      {{ end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{ end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+

--- a/charts/botkube/templates/ingress.yaml
+++ b/charts/botkube/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.ingress.create }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "botkube.fullname" . }}
+  labels: 
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}  
+    app: botkube
+  annotations:
+    {{- if .Values.ingress.annotations }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- end }}
+spec:
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+{{- end }}
+  rules:
+  - http:
+      paths:
+        - path: {{ .Values.ingress.urlPath }}
+          backend:
+            serviceName: {{ include "botkube.fullname" . }}
+            servicePort: {{ .Values.communications.teams.port }}
+    {{- if .Values.ingress.host }}
+    host: {{ .Values.ingress.host }}
+    {{- end }}
+{{- end -}}

--- a/charts/botkube/templates/podsecuritypolicy.yaml
+++ b/charts/botkube/templates/podsecuritypolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "botkube.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  allowedUnsafeSysctls: ['*']
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes: ['*']
+{{ end }}

--- a/charts/botkube/templates/secret.yaml
+++ b/charts/botkube/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.config.ssl.enabled }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "botkube.fullname" . }}-certificate-secret
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  ca-certificates.crt: {{ .Files.Get (printf "%s" .Values.config.ssl.cert) | b64enc }}
+
+{{ end }}

--- a/charts/botkube/templates/service.yaml
+++ b/charts/botkube/templates/service.yaml
@@ -1,0 +1,26 @@
+{{- if or .Values.serviceMonitor.enabled .Values.communications.teams.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "botkube.fullname" . }}
+  labels: 
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}  
+    app: botkube
+spec:
+  type: ClusterIP
+  ports:
+  {{- if .Values.serviceMonitor.enabled }}
+  - name: {{ .Values.service.name }}
+    port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+  {{- end }}
+  {{- if .Values.communications.teams.enabled }}
+  - name: "teams"
+    port: {{ .Values.communications.teams.port }}
+  {{- end }}
+  selector:
+    app: botkube 
+{{- end }}

--- a/charts/botkube/templates/serviceaccount.yaml
+++ b/charts/botkube/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "botkube.serviceAccountName" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/botkube/templates/servicemonitor.yaml
+++ b/charts/botkube/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "botkube.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    port: {{ .Values.serviceMonitor.port }}
+    path: {{ .Values.serviceMonitor.path }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "botkube.name" . }}
+      helm.sh/chart: {{ include "botkube.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      component: controller
+      app: botkube
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/botkube/values.schema.json
+++ b/charts/botkube/values.schema.json
@@ -1,0 +1,288 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "replicaCount": {
+            "type": "integer",
+            "default": 1
+        },
+        "extraAnnotations": {
+            "type": "object",
+            "default": "{}"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "default": ""
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "repository": {
+                    "type": "string",
+                    "default": "infracloudio/botkube"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "default": "IfNotPresent"
+                },
+                "tag": {
+                    "type": "string",
+                    "default": "v0.12.0"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "default": ""
+        },
+        "podSecurityPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "runAsUser": {
+                    "type": "integer",
+                    "default": 101
+                },
+                "runAsGroup": {
+                    "type": "integer",
+                    "default": 101
+                }
+            }
+        },
+        "logLevel": {
+            "type": "string",
+            "default": "info"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array"
+                },
+                "recommendations": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "ssl": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                },
+                "settings": {
+                    "type": "object",
+                    "properties": {
+                        "clustername": {
+                            "type": "string",
+                            "default": "not-configured"
+                        },
+                        "kubectl": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "commands": {
+                                    "type": "object",
+                                    "properties": {
+                                        "verbs": {
+                                            "type": "array",
+                                            "default": ["deployments", "pods", "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes"]
+                                        },
+                                        "resources": {
+                                            "type": "array",
+                                            "default": ["api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth"]
+                                        }
+                                    }
+                                },
+                                "defaultNamespace": {
+                                    "type": "string",
+                                    "default": "defaul"
+                                },
+                                "restrictAccess": {
+                                    "type": "boolean",
+                                    "default": false
+                                }   
+                            }
+                        },
+                        "configwatcher": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "upgradeNotifier": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                }
+            }
+        },
+        "communications": {
+            "properties": {
+                "existingSecret": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "existingSecretName": {
+                    "type": "string",
+                    "default": ""
+                },
+                "slack": {
+                    "type": "object"
+                },
+                "mattermost": {
+                    "type": "object"
+                },
+                "teams": {
+                    "type": "object"
+                },
+                "discord": {
+                    "type": "object"
+                },
+                "elasticsearch": {
+                    "type": "object"
+                },
+                "webhook": {
+                    "type": "object"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "metrics"
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 2112
+                },
+                "targetPort": {
+                    "type": "integer",
+                    "default": 2112
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": "{}"
+                },
+                "host": {
+                    "type": "string",
+                    "default": "HOST"
+                },
+                "urlPath": {
+                    "type": "string",
+                    "default": "/"
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "secretName": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "interval": {
+                    "type": "string",
+                    "default": "10s"
+                },
+                "path": {
+                    "type": "string",
+                    "default": "/metrics"
+                },
+                "port": {
+                    "type": "string",
+                    "default": "metrics"
+                },
+                "labels": {
+                    "type": "object",
+                    "default": "{}"
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "default": "{}"
+        },
+        "extraEnv": {
+            "type": "object",
+            "default": "{}"
+        },
+        "nodeSelector": {
+            "type": "object",
+            "default": "{}"
+        },
+        "tolerations": {
+            "type": "array",
+            "default": "[]"
+        },
+        "affinity": {
+            "type": "object",
+            "default": "{}"
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "rules": {
+                    "type": "array"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": "{}"
+                }
+            }
+        }
+    }
+}

--- a/charts/botkube/values.yaml
+++ b/charts/botkube/values.yaml
@@ -377,7 +377,9 @@ affinity: {}
 rbac:
   create: true
   rules:
-    ls
+    - apiGroups: ["*"]
+      resources: ["*"]
+      verbs: ["get", "watch", "list"]
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/botkube/values.yaml
+++ b/charts/botkube/values.yaml
@@ -335,8 +335,8 @@ service:
 # Ingress settings to expose teams endpoint
 ingress:
   create: false
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
   host: 'HOST'
   urlPath: "/"
   tls:
@@ -365,7 +365,7 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-extraEnv:   # Extra environment variables to pass to the BotKube container, example HTTP_PROXY
+extraEnv: {}  # Extra environment variables to pass to the BotKube container, example HTTP_PROXY
   # HTTP_PROXY: <proxyURL>:<port>
 
 nodeSelector: {}
@@ -377,9 +377,7 @@ affinity: {}
 rbac:
   create: true
   rules:
-    - apiGroups: ["*"]
-      resources: ["*"]
-      verbs: ["get", "watch", "list"]
+    ls
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/botkube/values.yaml
+++ b/charts/botkube/values.yaml
@@ -219,21 +219,21 @@ config:
         - delete
         - error
     # Custom resource example
-    #- name: velero.io/v1/backups
-    #  namespaces:
-    #    include:
-    #      - all
-    #    ignore:
-    #      -
-    #  events:
-    #    - create
-    #    - update
-    #    - delete
-    #    - error
-    #  updateSetting:
-    #    includeDiff: true
-    #    fields:
-    #      - status.phase
+    # - name: velero.io/v1/backups
+    #   namespaces:
+    #     include:
+    #       - all
+    #     ignore:
+    #       -
+    #   events:
+    #     - create
+    #     - update
+    #     - delete
+    #     - error
+    #   updateSetting:
+    #     includeDiff: true
+    #     fields:
+    #       - status.phase
 
   # Check true if you want to receive recommendations
   # about the best practices for the created resource
@@ -241,7 +241,7 @@ config:
 
   ssl:                                           # For using custom SSL certificates
     enabled: false                               # Set to true and specify cert path in the next line after uncommenting
-    #cert:                                       # SSL Certificate file e.g certs/my-cert.crt
+    # cert:                                       # SSL Certificate file e.g certs/my-cert.crt
 
   # Setting to support multiple clusters
   settings:
@@ -256,7 +256,7 @@ config:
         # method which are allowed
         verbs: ["api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth"]
         # resource configuration which is allowed
-        resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes" ]
+        resources: ["deployments", "pods", "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes"]
       # set Namespace to execute BotKube kubectl commands by default
       defaultNamespace: default
       # Set true to enable commands execution from configured channel only
@@ -268,7 +268,7 @@ config:
 
 # Communication settings
 communications:
-  
+
   # Communication secret already existing
   existingSecret: false
   existingSecretName: ""
@@ -278,7 +278,7 @@ communications:
     enabled: false
     channel: 'SLACK_CHANNEL'                   # Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in
     token: 'SLACK_API_TOKEN'
-    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified) 
+    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
 
   # Settings for Mattermost
   mattermost:
@@ -297,15 +297,14 @@ communications:
     notiftype: short
     port: 3978
 
-  
   # Settings for Discord
   discord:
     enabled: false
-    token: 'DISCORD_TOKEN'                      # BotKube Bot Token 
-    botid: 'DISCORD_BOT_ID'                     # BotKube Application Client ID 
-    channel: 'DISCORD_CHANNEL_ID'               # Discord Channel id for receiving BotKube alerts 
+    token: 'DISCORD_TOKEN'                      # BotKube Bot Token
+    botid: 'DISCORD_BOT_ID'                     # BotKube Application Client ID
+    channel: 'DISCORD_CHANNEL_ID'               # Discord Channel id for receiving BotKube alerts
     notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-  
+
   # Settings for ELS
   elasticsearch:
     enabled: false
@@ -331,7 +330,7 @@ communications:
 service:
   name: metrics
   port: 2112
-  targetPort: 2112  
+  targetPort: 2112
 
 # Ingress settings to expose teams endpoint
 ingress:
@@ -344,7 +343,6 @@ ingress:
     enabled: false
     secretName: ''
 
-            
 serviceMonitor:
   ## If true, a ServiceMonitor CR is created for a BotKube
   ##  https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor
@@ -353,7 +351,7 @@ serviceMonitor:
   interval: 10s
   path: /metrics
   port: metrics
-  labels: {} 
+  labels: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -368,8 +366,8 @@ resources: {}
   #  memory: 128Mi
 
 extraEnv:   # Extra environment variables to pass to the BotKube container, example HTTP_PROXY
-  #HTTP_PROXY: <proxyURL>:<port>
-  
+  # HTTP_PROXY: <proxyURL>:<port>
+
 nodeSelector: {}
 
 tolerations: []
@@ -382,11 +380,12 @@ rbac:
     - apiGroups: ["*"]
       resources: ["*"]
       verbs: ["get", "watch", "list"]
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  #name:
+  # name:
   # annotations for the service account
   annotations: {}

--- a/charts/botkube/values.yaml
+++ b/charts/botkube/values.yaml
@@ -1,0 +1,392 @@
+# Default values for BotKube.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+# Extra annotations to pass to the BotKube pod
+extraAnnotations: {}
+# Priority class name for the pod
+priorityClassName: ""
+image:
+  repository: infracloudio/botkube
+  pullPolicy: IfNotPresent
+  ## default tag is appVersion from Chart.yaml. If you want to use
+  ## some other tag then it can be specified here
+  tag: v0.12.0
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Enable podSecurityPolicy to allow BotKube to run in restricted clusters
+podSecurityPolicy:
+  enabled: false
+
+# Configure securityContext to manage user Privileges in pods
+# set to run as a Non-Privileged user by default
+securityContext:
+  runAsUser: 101
+  runAsGroup: 101
+
+# set one of the log levels- info, warn, debug, error, fatal, panic
+logLevel: info
+
+config:
+  ## Resources you want to watch
+  resources:
+    - name: v1/pods             # Name of the resource. Resource name must be in group/version/resource (G/V/R) format
+                                # resource name should be plural (e.g apps/v1/deployments, v1/pods)
+      namespaces:               # List of namespaces, "all" will watch all the namespaces
+        include:
+          - all
+        ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+          -                     # example : include [all], ignore [x,y,secret-ns-*]
+      events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
+        - create
+        - delete
+        - error
+    - name: v1/services
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: apps/v1/deployments
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - update
+        - delete
+        - error
+      updateSetting:
+        includeDiff: true
+        fields:
+          - spec.template.spec.containers[*].image
+          - status.availableReplicas
+    - name: apps/v1/statefulsets
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - update
+        - delete
+        - error
+      updateSetting:
+        includeDiff: true
+        fields:
+          - spec.template.spec.containers[*].image
+          - status.readyReplicas
+    - name: networking.k8s.io/v1beta1/ingresses
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: v1/nodes
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: v1/namespaces
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: v1/persistentvolumes
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: v1/persistentvolumeclaims
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: v1/configmaps
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: apps/v1/daemonsets
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - update
+        - delete
+        - error
+      updateSetting:
+        includeDiff: true
+        fields:
+          - spec.template.spec.containers[*].image
+          - status.numberReady
+    - name: batch/v1/jobs
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - update
+        - delete
+        - error
+      updateSetting:
+        includeDiff: true
+        fields:
+          - spec.template.spec.containers[*].image
+          - status.conditions[*].type
+    - name: rbac.authorization.k8s.io/v1/roles
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: rbac.authorization.k8s.io/v1/rolebindings
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: rbac.authorization.k8s.io/v1/clusterrolebindings
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    - name: rbac.authorization.k8s.io/v1/clusterroles
+      namespaces:
+        include:
+          - all
+        ignore:
+          -
+      events:
+        - create
+        - delete
+        - error
+    # Custom resource example
+    #- name: velero.io/v1/backups
+    #  namespaces:
+    #    include:
+    #      - all
+    #    ignore:
+    #      -
+    #  events:
+    #    - create
+    #    - update
+    #    - delete
+    #    - error
+    #  updateSetting:
+    #    includeDiff: true
+    #    fields:
+    #      - status.phase
+
+  # Check true if you want to receive recommendations
+  # about the best practices for the created resource
+  recommendations: true
+
+  ssl:                                           # For using custom SSL certificates
+    enabled: false                               # Set to true and specify cert path in the next line after uncommenting
+    #cert:                                       # SSL Certificate file e.g certs/my-cert.crt
+
+  # Setting to support multiple clusters
+  settings:
+    # Cluster name to differentiate incoming messages
+    clustername: not-configured
+    # Kubectl executor configs
+    kubectl:
+      # Set true to enable kubectl commands execution
+      enabled: false
+      # List of allowed commands
+      commands:
+        # method which are allowed
+        verbs: ["api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth"]
+        # resource configuration which is allowed
+        resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes" ]
+      # set Namespace to execute BotKube kubectl commands by default
+      defaultNamespace: default
+      # Set true to enable commands execution from configured channel only
+      restrictAccess: false
+    # Set true to enable config watcher
+    configwatcher: true
+    # Set false to disable upgrade notification
+    upgradeNotifier: true
+
+# Communication settings
+communications:
+  
+  # Communication secret already existing
+  existingSecret: false
+  existingSecretName: ""
+
+  # Settings for Slack
+  slack:
+    enabled: false
+    channel: 'SLACK_CHANNEL'                   # Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in
+    token: 'SLACK_API_TOKEN'
+    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified) 
+
+  # Settings for Mattermost
+  mattermost:
+    enabled: false
+    url: 'MATTERMOST_SERVER_URL'                # URL where Mattermost is running. e.g https://example.com:9243
+    token: 'MATTERMOST_TOKEN'                   # Personal Access token generated by BotKube user
+    team: 'MATTERMOST_TEAM'                     # Mattermost Team to configure with BotKube
+    channel: 'MATTERMOST_CHANNEL'               # Mattermost Channel for receiving BotKube alerts
+    notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+
+  # Settings for MS Teams
+  teams:
+    enabled: false
+    appID: 'APPLICATION_ID'
+    appPassword: 'APPLICATION_PASSWORD'
+    notiftype: short
+    port: 3978
+
+  
+  # Settings for Discord
+  discord:
+    enabled: false
+    token: 'DISCORD_TOKEN'                      # BotKube Bot Token 
+    botid: 'DISCORD_BOT_ID'                     # BotKube Application Client ID 
+    channel: 'DISCORD_CHANNEL_ID'               # Discord Channel id for receiving BotKube alerts 
+    notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+  
+  # Settings for ELS
+  elasticsearch:
+    enabled: false
+    awsSigning:
+      enabled: false                            # enable awsSigning using IAM for Elasticsearch hosted on AWS, if true make sure AWS environment variables are set. Refer https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+      awsRegion: "us-east-1"                    # AWS region where Elasticsearch is deployed
+      roleArn: ''                               # AWS IAM Role arn to assume for credentials, use this only if you don't want to use the EC2 instance role or not running on AWS instance
+    server: 'ELASTICSEARCH_ADDRESS'             # e.g https://example.com:9243
+    username: 'ELASTICSEARCH_USERNAME'          # Basic Auth
+    password: 'ELASTICSEARCH_PASSWORD'
+    # ELS index settings
+    index:
+      name: botkube
+      type: botkube-event
+      shards: 1
+      replicas: 0
+
+  # Settings for Webhook
+  webhook:
+    enabled: false
+    url: 'WEBHOOK_URL'                          # e.g https://example.com:80
+
+service:
+  name: metrics
+  port: 2112
+  targetPort: 2112  
+
+# Ingress settings to expose teams endpoint
+ingress:
+  create: false
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  host: 'HOST'
+  urlPath: "/"
+  tls:
+    enabled: false
+    secretName: ''
+
+            
+serviceMonitor:
+  ## If true, a ServiceMonitor CR is created for a BotKube
+  ##  https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor
+  ##
+  enabled: false
+  interval: 10s
+  path: /metrics
+  port: metrics
+  labels: {} 
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+extraEnv:   # Extra environment variables to pass to the BotKube container, example HTTP_PROXY
+  #HTTP_PROXY: <proxyURL>:<port>
+  
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+rbac:
+  create: true
+  rules:
+    - apiGroups: ["*"]
+      resources: ["*"]
+      verbs: ["get", "watch", "list"]
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  #name:
+  # annotations for the service account
+  annotations: {}


### PR DESCRIPTION
Extend botkube helm chart to be able to use an existing secret for defining the communication settings