### PR TITLE
Added configuration options for services

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,3 @@
+chart-dirs:
+  - charts
+validate-maintainers: false

--- a/.github/workflows/lint-install.yml
+++ b/.github/workflows/lint-install.yml
@@ -1,6 +1,9 @@
 name: Lint and Install Charts
 
-on: pull_request
+on: 
+  pull_request:
+    branches:
+      - master
 
 jobs:
   changes:
@@ -10,7 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0
+          
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -30,12 +35,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.1.0
-        with:
-          command: lint
-          config: ct.yaml
+        run: ct lint --config .github/ct.yaml
 
   install-test:
     runs-on: ubuntu-latest
@@ -48,15 +53,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
       - name: Create k3s Cluster
         uses: AbsaOSS/k3d-action@v1.3.1
         with:
           cluster-name: "test-cluster"
           args: --config .github/k3d.yaml
 
-      - name: Run chart-testing (lint)
+      - name: Run chart-testing (install)
         id: install
-        uses: helm/chart-testing-action@v1.1.0
-        with:
-          command: install
-          config: ct.yaml
+        run: ct install --config .github/ct.yaml

--- a/charts/botkube/Chart.yaml
+++ b/charts/botkube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: botkube
 home: https://www.botkube.io
-version: v0.12.2
+version: v0.12.3
 appVersion: v0.12.0
 description: Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster,
  debug deployments and run specific checks on resources in the cluster.

--- a/charts/botkube/README.md
+++ b/charts/botkube/README.md
@@ -105,6 +105,9 @@ serviceAccount:
 | resources | object | `{}` |  |
 | securityContext.runAsGroup | int | `101` |  |
 | securityContext.runAsUser | int | `101` |  |
+| service.type | string | `"ClusterIP"` |  |
+| service.clusterIP | string | `nil` |  |
+| service.loadBalancerIP | string | `nil` |  |
 | service.name | string | `"metrics"` |  |
 | service.port | int | `2112` |  |
 | service.targetPort | int | `2112` |  |

--- a/charts/botkube/ci/ci-values.yaml
+++ b/charts/botkube/ci/ci-values.yaml
@@ -1,0 +1,17 @@
+settings:
+  # Cluster name to differentiate incoming messages
+  clustername: ci-test
+
+extraEnv:
+  TZ: Europe/Berlin
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector:
+  kubernetes.io/arch: amd64

--- a/charts/botkube/templates/service.yaml
+++ b/charts/botkube/templates/service.yaml
@@ -10,7 +10,19 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}  
     app: botkube
 spec:
+  {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
   type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- else if eq .Values.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- else }}
+  type: {{ .Values.service.type }}
+  {{- end }}
   ports:
   {{- if .Values.serviceMonitor.enabled }}
   - name: {{ .Values.service.name }}

--- a/charts/botkube/values.schema.json
+++ b/charts/botkube/values.schema.json
@@ -166,6 +166,20 @@
         "service": {
             "type": "object",
             "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "ClusterIP"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "format": "ipv4",
+                    "default": null
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "format": "ipv4",
+                    "default": null
+                },
                 "name": {
                     "type": "string",
                     "default": "metrics"

--- a/charts/botkube/values.yaml
+++ b/charts/botkube/values.yaml
@@ -328,6 +328,9 @@ communications:
     url: 'WEBHOOK_URL'                          # e.g https://example.com:80
 
 service:
+  type: ClusterIP                               # or LoadBalancer
+  # clusterIP:
+  # loadBalancerIP:
   name: metrics
   port: 2112
   targetPort: 2112

--- a/charts/cert-manager-webhook-duckdns/.gitignore
+++ b/charts/cert-manager-webhook-duckdns/.gitignore
@@ -1,0 +1,2 @@
+charts/
+Chart.lock

--- a/charts/cert-manager-webhook-duckdns/.gitignore
+++ b/charts/cert-manager-webhook-duckdns/.gitignore
@@ -1,2 +1,0 @@
-charts/
-Chart.lock

--- a/charts/cert-manager-webhook-duckdns/Chart.yaml
+++ b/charts/cert-manager-webhook-duckdns/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: cert-manager-webhook-duckdns
-version: v1.2.2
+version: v1.2.3
 appVersion: v1.2.2
 description: A Helm chart for cert manager webhook solver for ACME DNS01 challenge via DuckDNS
 home: https://github.com/ebrianne/cert-manager-webhook-duckdns
@@ -16,3 +16,8 @@ maintainers:
   - name: ebrianne
     email: eldwan35@gmail.com
     url: https://ebrianne.technolab.duckdns.org
+dependencies:
+  - name: cert-manager
+    version: v1.3.1
+    repository: https://charts.jetstack.io
+    condition: cert-manager.enabled

--- a/charts/cert-manager-webhook-duckdns/Chart.yaml
+++ b/charts/cert-manager-webhook-duckdns/Chart.yaml
@@ -16,8 +16,3 @@ maintainers:
   - name: ebrianne
     email: eldwan35@gmail.com
     url: https://ebrianne.technolab.duckdns.org
-dependencies:
-  - name: cert-manager
-    version: v1.3.1
-    repository: https://charts.jetstack.io
-    condition: cert-manager.enabled

--- a/charts/cert-manager-webhook-duckdns/README.md
+++ b/charts/cert-manager-webhook-duckdns/README.md
@@ -78,6 +78,8 @@ The following table lists the configurable parameters of the cert-manager-webhoo
 | `nameOverride`                     | Name override for the chart                     | `""`                                                    |
 | `fullnameOverride`                 | Full name override for the chart                | `""`                                                    |
 | `service.type`                     | Service type                                    | `ClusterIP`                                             |
+| `service.clusterIP`                | Service cluster IP                              | `nil`                                                   |
+| `service.loadBalancerIP`           | Service LB IP                                   | `nil`                                                   |
 | `service.port`                     | Service port                                    | `443`                                                   |
 | `resources`                        | Pod ressources                                  | `nil`                                                   |
 | `nodeSelector`                     | Node selector                                   | `nil`                                                   |

--- a/charts/cert-manager-webhook-duckdns/ci/ci-values.yaml
+++ b/charts/cert-manager-webhook-duckdns/ci/ci-values.yaml
@@ -1,0 +1,30 @@
+cert-manager:
+  enabled: true
+  installCRDs: true
+
+  extraArgs:
+    - --dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53
+    - --dns01-recursive-nameservers-only
+
+  podDnsPolicy: "None"
+  podDnsConfig:
+    nameservers:
+      - "1.1.1.1"
+      - "8.8.8.8"
+
+duckdns:
+  token: test
+
+extraEnv:
+  TZ: Europe/Berlin
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector:
+  kubernetes.io/arch: amd64

--- a/charts/cert-manager-webhook-duckdns/ci/ci-values.yaml
+++ b/charts/cert-manager-webhook-duckdns/ci/ci-values.yaml
@@ -1,17 +1,3 @@
-cert-manager:
-  enabled: true
-  installCRDs: true
-
-  extraArgs:
-    - --dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53
-    - --dns01-recursive-nameservers-only
-
-  podDnsPolicy: "None"
-  podDnsConfig:
-    nameservers:
-      - "1.1.1.1"
-      - "8.8.8.8"
-
 duckdns:
   token: test
 

--- a/charts/cert-manager-webhook-duckdns/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-duckdns/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+          {{- if .Values.extraEnv }}
+          {{- range $name, $value := .Values.extraEnv }}
+            - name: {{ $name }}
+              value: {{ quote $value }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: https
               containerPort: 443
@@ -55,21 +61,23 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+          {{- if .Values.resources }}
           resources:
-      {{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
       volumes:
         - name: certs
           secret:
             secretName: {{ include "cert-manager-webhook-duckdns.servingCertificate" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
+      {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}

--- a/charts/cert-manager-webhook-duckdns/templates/service.yaml
+++ b/charts/cert-manager-webhook-duckdns/templates/service.yaml
@@ -8,7 +8,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- else if eq .Values.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- else }}
   type: {{ .Values.service.type }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: https

--- a/charts/cert-manager-webhook-duckdns/values.schema.json
+++ b/charts/cert-manager-webhook-duckdns/values.schema.json
@@ -6,6 +6,15 @@
             "type": "object",
             "default": "{}"
         },
+        "cert-manager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
         "certManager": {
             "type": "object",
             "properties": {
@@ -93,6 +102,10 @@
                 }
             }
         },
+        "extraEnv": {
+            "type": "object",
+            "default": "{}"
+        },
         "logLevel": {
             "type": "integer",
             "default": 2
@@ -119,6 +132,16 @@
                 "type": {
                     "type": "string",
                     "default": "ClusterIP"
+                },
+                "clusterIP": {
+                    "type": "string",
+                    "format": "ipv4",
+                    "default": null
+                },
+                "loadBalancerIP": {
+                    "type": "string",
+                    "format": "ipv4",
+                    "default": null
                 }
             }
         },

--- a/charts/cert-manager-webhook-duckdns/values.yaml
+++ b/charts/cert-manager-webhook-duckdns/values.yaml
@@ -1,6 +1,3 @@
-cert-manager:
-  enabled: false
-
 # The GroupName here is used to identify your company or business unit that
 # created this webhook.
 # For example, this may be "acme.mycompany.com".

--- a/charts/cert-manager-webhook-duckdns/values.yaml
+++ b/charts/cert-manager-webhook-duckdns/values.yaml
@@ -1,3 +1,6 @@
+cert-manager:
+  enabled: false
+
 # The GroupName here is used to identify your company or business unit that
 # created this webhook.
 # For example, this may be "acme.mycompany.com".
@@ -34,11 +37,15 @@ image:
   pullPolicy: IfNotPresent
   # pullSecret: ""
 
+extraEnv: {}
+
 nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: ClusterIP
+  type: ClusterIP                             # or LoadBalancer
+  # clusterIP:
+  # loadBalancerIP:
   port: 443
 
 resources: {}


### PR DESCRIPTION
Adding possibility to configure the service type for charts `botkube` and `cert-manager-duckdns-webhook`

```yml
service:
  - type: ClusterIP    # or LoadBalancer
  - clusterIP:
  - loadBalancerIP:
```

See PR#18 